### PR TITLE
hotfix(3.4.1): pin `eslint-plugin-vue` to exact version `10.6.2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vue-editor",
-	"version": "3.4.0",
+	"version": "3.4.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vue-editor",
-			"version": "3.4.0",
+			"version": "3.4.1",
 			"hasInstallScript": true,
 			"license": "ISC",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
 				"eslint": "^8.57.0",
 				"eslint-plugin-json": "^3.1.0",
 				"eslint-plugin-prettier": "^5.5.5",
-				"eslint-plugin-vue": "^10.6.2",
+				"eslint-plugin-vue": "10.6.2",
 				"husky": "^9.1.7",
 				"lint-staged": "^16.2.7",
 				"postcss": "^8.5.6",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "3.4.0",
+	"version": "3.4.1",
 	"private": true,
 	"name": "vue-editor",
 	"description": "Editor online of code made with Vue.",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"eslint": "^8.57.0",
 		"eslint-plugin-json": "^3.1.0",
 		"eslint-plugin-prettier": "^5.5.5",
-		"eslint-plugin-vue": "^10.6.2",
+		"eslint-plugin-vue": "10.6.2",
 		"husky": "^9.1.7",
 		"lint-staged": "^16.2.7",
 		"postcss": "^8.5.6",


### PR DESCRIPTION
# hotfix(3.4.1): pin `eslint-plugin-vue` to exact version `10.6.2`

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P1 | XS | 17-01-2026 | 17-01-2026 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| N/A — This change has no visual impact. | N/A — This change has no visual impact. |

## 🔄 Type of Change

- [x] Bug fix
- [ ] Breaking change
- [x] Dependency
- [ ] New feature
- [ ] Improvement
- [x] Configuration
- [x] Documentation
- [ ] CI/CD

## 📝 Summary

- Hotfix to resolve `npm install` failure caused by automatic update of `eslint-plugin-vue` to version `10.7.0`, which is incompatible with ESLint 8 legacy config format

## 📋 Changes Made

### Dependencies
- Pin `eslint-plugin-vue` to exact version `10.6.2` (remove caret `^`)

### Version
- Bump version from `3.4.0` to `3.4.1`

## 🧪 Tests

- [x] Verify install completes without errors:

```bash
npm install
```
- [x] Verify lint passes successfully:

```bash
npm run lint
```

## 📌 Notes

- The `eslint-plugin-vue@10.7.0` introduced TypeScript in build process ([#2916](https://github.com/vuejs/eslint-plugin-vue/pull/2916))
- This generates `export default` which causes error: "Unexpected top-level property default"
- Incompatible with ESLint 8 legacy config format (`.eslintrc.js`)
- Upgrading to ESLint 9 is not viable because `@vue/cli-plugin-eslint` does not support it

## 🔗 References

### Documentation
- https://github.com/vuejs/eslint-plugin-vue/pull/2916

### Related Issues
- #821